### PR TITLE
Feature/access name of current repo

### DIFF
--- a/EXAMPLE_OUTPUT.md
+++ b/EXAMPLE_OUTPUT.md
@@ -42,6 +42,9 @@
   - **TOTAL_REPOS_SIZE_GB**: 1.35
 - **TOTAL_REPOSITORIES**: 64
 
+## Current Repository
+probablykasper/readme-template-action
+
 ## 3 most starred repos
 
 | ⭐️Stars   | 📦Repo    | 📚Description |

--- a/EXAMPLE_TEMPLATE.md
+++ b/EXAMPLE_TEMPLATE.md
@@ -100,6 +100,9 @@ module.exports = {
   - **TOTAL_REPOS_SIZE_GB**: {{ TOTAL_REPOS_SIZE_GB }}
 - **TOTAL_REPOSITORIES**: {{ TOTAL_REPOSITORIES }}
 
+## Current Repository
+{{ CURRENT_REPO_FULL_NAME }}
+
 ## 3 most starred repos
 
 | ⭐️Stars   | 📦Repo    | 📚Description |

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ By default, it takes `TEMPLATE.md` and outputs `README.md`.
 
 ## Inputs
 
-| name         | type   | default         | description |
-| ------------ | ------ | --------------- | ----------- |
-| token        | string |                 | GitHub personal access token used to fetch data. Pass a secret by for instance using `${{ secrets.README_TEMPLATE_TOKEN }}`. [Go here](https://github.com/settings/tokens/new?scopes=read:user) to generate one with the `read:user` scope
-| template     | string | `"TEMPLATE.md"` | Template file path
-| readme       | string | `"README.md"`   | Output file path
+| name         | required | type   | default         | description |
+| ------------ | ---      | ------ | --------------- | ----------- |
+| token        | yes      | string |                 | GitHub personal access token used to fetch data. Pass a secret by for instance using `${{ secrets.README_TEMPLATE_TOKEN }}`. [Go here](https://github.com/settings/tokens/new?scopes=read:user) to generate one with the `read:user` scope
+| template     | yes      | string | `"TEMPLATE.md"` | Template file path
+| readme       | yes      | string | `"README.md"`   | Output file path
 
 ## Example usage
 
@@ -99,6 +99,7 @@ My most starred repos:
 | {{ TOTAL_REPOS_SIZE_MB }} | 707.5
 | {{ TOTAL_REPOS_SIZE_GB }} | 0.71
 | {{ TOTAL_REPOSITORIES }}  | 46
+| {{ CURRENT_REPO_FULL_NAME }} | probablykasper/readme-template-action
 
 ### Variables you can put inside `repo` loops
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -11549,6 +11549,10 @@ var github = __nccwpck_require__(438);
 const ghToken = core.getInput('TOKEN', { required: true });
 core.setSecret(ghToken);
 const octokit = github.getOctokit(ghToken);
+function getCurrentRepoFullName() {
+    const currentRepoFullName = process.env.GITHUB_REPOSITORY;
+    return { 'CURRENT_REPO_FULL_NAME': currentRepoFullName };
+}
 async function getUser() {
     const queryResult = await octokit.graphql(`
     query {
@@ -11811,6 +11815,11 @@ async function run() {
         const user = await getUser();
         console.log('    - Injecting');
         outputStr = inject(outputStr, user);
+        console.log('Current repository name');
+        console.log('    - Fetching');
+        const currentRepo = getCurrentRepoFullName();
+        console.log('    - Injecting');
+        outputStr = inject(outputStr, currentRepo);
         if (!customTemplate['3_MOST_STARRED_REPOS']) {
             customTemplate['3_MOST_STARRED_REPOS'] = {
                 type: 'repos',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,231 @@
 {
   "name": "readme-template",
+  "lockfileVersion": 2,
   "requires": true,
-  "lockfileVersion": 1,
+  "packages": {
+    "": {
+      "name": "readme-template",
+      "dependencies": {
+        "@actions/core": "^1.2.6",
+        "@actions/github": "^4.0.0",
+        "@vercel/ncc": "^0.28.0",
+        "moment": "^2.29.1",
+        "require-from-string": "^2.0.2"
+      },
+      "devDependencies": {
+        "typescript": "^4.2.3"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
+    },
+    "node_modules/@actions/github": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-4.0.0.tgz",
+      "integrity": "sha512-Ej/Y2E+VV6sR9X7pWL5F3VgEWrABaT292DRqRU6R4hnQjPtC/zD3nagxVdXWiRQvYDh8kHXo7IDmG42eJ/dOMA==",
+      "dependencies": {
+        "@actions/http-client": "^1.0.8",
+        "@octokit/core": "^3.0.0",
+        "@octokit/plugin-paginate-rest": "^2.2.3",
+        "@octokit/plugin-rest-endpoint-methods": "^4.0.0"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.8.tgz",
+      "integrity": "sha512-G4JjJ6f9Hb3Zvejj+ewLLKLf99ZC+9v+yCxoYf9vSyH+WkzPLB2LuUtRMGNkooMqdugGBFStIKXOuvH1W+EctA==",
+      "dependencies": {
+        "tunnel": "0.0.6"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
+      "integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
+      "dependencies": {
+        "@octokit/types": "^5.0.0"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.1.2.tgz",
+      "integrity": "sha512-AInOFULmwOa7+NFi9F8DlDkm5qtZVmDQayi7TUgChE3yeIGPq0Y+6cAEXPexQ3Ea+uZy66hKEazR7DJyU+4wfw==",
+      "dependencies": {
+        "@octokit/auth-token": "^2.4.0",
+        "@octokit/graphql": "^4.3.1",
+        "@octokit/request": "^5.4.0",
+        "@octokit/types": "^5.0.0",
+        "before-after-hook": "^2.1.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.5.tgz",
+      "integrity": "sha512-70K5u6zd45ItOny6aHQAsea8HHQjlQq85yqOMe+Aj8dkhN2qSJ9T+Q3YjUjEYfPRBcuUWNgMn62DQnP/4LAIiQ==",
+      "dependencies": {
+        "@octokit/types": "^5.0.0",
+        "is-plain-object": "^4.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.4.tgz",
+      "integrity": "sha512-ITpZ+dQc0cXAW1FmDkHJJM+8Lb6anUnin0VB5hLBilnYVdLC0ICFU/KIvT7OXfW9S81DE3U4Vx2EypDG1OYaPA==",
+      "dependencies": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.3.0.tgz",
+      "integrity": "sha512-Ye2ZJreP0ZlqJQz8fz+hXvrEAEYK4ay7br1eDpWzr6j76VXs/gKqxFcH8qRzkB3fo/2xh4Vy9VtGii4ZDc9qlA==",
+      "dependencies": {
+        "@octokit/types": "^5.2.0"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.1.2.tgz",
+      "integrity": "sha512-PTI7wpbGEZ2IR87TVh+TNWaLcgX/RsZQalFbQCq8XxYUrQ36RHyERrHSNXFy5gkWpspUAOYRSV707JJv6BhqJA==",
+      "dependencies": {
+        "@octokit/types": "^5.1.1",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.7.tgz",
+      "integrity": "sha512-FN22xUDP0i0uF38YMbOfx6TotpcENP5W8yJM1e/LieGXn6IoRxDMnBf7tx5RKSW4xuUZ/1P04NFZy5iY3Rax1A==",
+      "dependencies": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^5.0.0",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^4.0.0",
+        "node-fetch": "^2.3.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
+      "integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
+      "dependencies": {
+        "@octokit/types": "^5.0.1",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.4.1.tgz",
+      "integrity": "sha512-OlMlSySBJoJ6uozkr/i03nO5dlYQyE05vmQNZhAh9MyO4DPBP88QlwsDVLmVjIMFssvIZB6WO0ctIGMRG+xsJQ==",
+      "dependencies": {
+        "@types/node": ">= 8"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "14.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
+      "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA=="
+    },
+    "node_modules/@vercel/ncc": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.28.0.tgz",
+      "integrity": "sha512-dKFgT0r61LmKcMsriSkoxOSp+A45ADRFxrYXvFMmuLEpvc2a+fBAIh8Pg1Q7RYtPTZE1kX/Tk+nmOpNGyb5P2w==",
+      "bin": {
+        "ncc": "dist/ncc/cli.js"
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
+      "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A=="
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
+    "node_modules/is-plain-object": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
+      "integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
+      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  },
   "dependencies": {
     "@actions/core": {
       "version": "1.2.6",

--- a/src/main.ts
+++ b/src/main.ts
@@ -95,6 +95,12 @@ async function run() {
     console.log('    - Injecting')
     outputStr = inject(outputStr, user)
 
+    console.log('Current repository name')
+    console.log('    - Fetching')
+    const currentRepo = queries.getCurrentRepoFullName()
+    console.log('    - Injecting')
+    outputStr = inject(outputStr, currentRepo)
+
     if (!customTemplate['3_MOST_STARRED_REPOS']) {
       customTemplate['3_MOST_STARRED_REPOS'] = {
         type: 'repos',

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -6,6 +6,11 @@ const ghToken = core.getInput('TOKEN', { required: true })
 core.setSecret(ghToken)
 export const octokit = github.getOctokit(ghToken)
 
+export function getCurrentRepoFullName() {
+  const currentRepoFullName = process.env.GITHUB_REPOSITORY
+  return {'CURRENT_REPO_FULL_NAME': currentRepoFullName}
+}
+
 export async function getUser() {
   const queryResult: any = await octokit.graphql(`
     query {


### PR DESCRIPTION
# Background
I am interested  in accessing the full name of the repository where the workflow is executing. As discussed in issue #4, one way of doing so is by creating a custom query; however, I found that approach too complex. 

# Scope
The purpose of this PR is to provide access to the full name of the repository where this workflow is executing without the need of creating a custom query.

With this new implementation we use the default environment variable `GITHUB_REPOSITORY` to accomplish the goal mentioned above.

From the template file, the user can then use the variable `{{CURRENT_REPO_FULL_NAME }}` to access the value in `GITHUB_REPOSITORY`.

# Notes
I could not find a contribution guideline so I made the following assumptions:
- I used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) as the standard for writing commit messages.
- I tried my best to follow the naming convention based on the existing code.

While installing the project, the file `package-lock.json` was automatically changed. I am not sure if the changes to this file should be included or not, please let me know.
